### PR TITLE
Lowered Cooldown to 3s

### DIFF
--- a/ArkhamOrigins.asl
+++ b/ArkhamOrigins.asl
@@ -51,14 +51,12 @@ start{
 }
 
 split{
-	int cooldown = 10000;
+	int cooldown = 3000;
 	int globalcount = vars.ccount + vars.lcount;
 
 	//Experimental Any% Features
 	if(settings["any%"] && vars.ccount == 4 && globalcount > 8) {vars.lcount = 4;} // Ensures that even if you get extra loads before getting to bane's hideout it won't screw up the counters
-	if(settings["any%"] && vars.lcount == 4 && vars.ccount < 5){
-		cooldown = 1000; //Alt way of forcing the fast travel cutscene after bane's hideout to split by making the cooldown 1s
-	}else if(settings["any%"] && vars.lcount == 9){
+	if(settings["any%"] && vars.lcount == 9){
 		cooldown = 90000; //Increases the cooldown for the split inside the sewers
 	}
 	


### PR DESCRIPTION
This way it's more compatible with glitchless, as there are multiple instances where the autosplitter may or may not split depending on how fast you are, now it will always split. This also removes one of the uses of the counters for the experimental setting, so the fast travel after Bane's hideout will always split. It also adds a couple of extra splits. (As a side note, the normal any% splits and experimental ones would now be identical except for the extended cooldown in the sewers).